### PR TITLE
feat: add stablecoin pricing from coingecko

### DIFF
--- a/aave_data/resources/financials_config.py
+++ b/aave_data/resources/financials_config.py
@@ -887,7 +887,31 @@ COINGECKO_TOKENS = {
         "chain": "ethereum",
         "decimals": 18,
         "start_date": "2023-04-01",
-    }
+    },
+    "USDC": {
+        "cg_id": "usd-coin",
+        "symbol": "USDC",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "chain": "ethereum",
+        "decimals": 6,
+        "start_date": "2022-01-01",
+    },
+    "USDT": {
+        "cg_id": "tether",
+        "symbol": "USDT",
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "chain": "ethereum",
+        "decimals": 6,
+        "start_date": "2022-01-01",
+    },
+    "DAI": {
+        "cg_id": "dai",
+        "symbol": "DAI",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "chain": "ethereum",
+        "decimals": 18,
+        "start_date": "2022-01-01",
+    },
 }
 
 CONFIG_COMPOUND_v2 = {


### PR DESCRIPTION
**Motivation:**

add USDT, USDC and DAI pricing from coingecko.  Pricing from Aave v2 oracle is too volatile for financials performance calcs due to translation from eth denominated pricing

**Modifications:**

Describe the modifications you've done.

**Result:**

After your change, what will change.
