### PR TITLE
feat: add treasury GHO holdings

### DIFF
--- a/aave_data/resources/financials_config.py
+++ b/aave_data/resources/financials_config.py
@@ -581,6 +581,10 @@ CONFIG_TOKENS = {
                     "address": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf",
                     "decimals": 18,
                 },
+                "GHO": {
+                    "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+                    "decimals": 18,
+                },
             }
         },
     },


### PR DESCRIPTION
**Motivation:**

Aave treasury now holds GHO tokens, add this so it's reflected in the treasury holdings on the frontend

**Modifications:**

Add GHO to the config for treasury holdings

